### PR TITLE
Werken met abstracte services ter voorbereiding op Integratietesten

### DIFF
--- a/PortalGenius.Api/Controllers/ItemController.cs
+++ b/PortalGenius.Api/Controllers/ItemController.cs
@@ -7,9 +7,9 @@ namespace PG_API.Controllers;
 [ApiController]
 public class ItemController : ControllerBase
 {
-    private readonly ArcGISService _argGISService;
+    private readonly IArcGISService _argGISService;
 
-    public ItemController(ArcGISService arcGISService)
+    public ItemController(IArcGISService arcGISService)
     {
         _argGISService = arcGISService;
     }
@@ -17,6 +17,6 @@ public class ItemController : ControllerBase
     [HttpGet("/")]
     public async Task<IActionResult> GetAllItems()
     {
-        return Ok(await _argGISService.GetAllItems());
+        return Ok(await _argGISService.GetAllItemsAsync());
     }
 }

--- a/PortalGenius.Api/Controllers/UserController.cs
+++ b/PortalGenius.Api/Controllers/UserController.cs
@@ -7,9 +7,9 @@ namespace PG_API.Controllers;
 [ApiController]
 public class UserController : ControllerBase
 {
-    private readonly ArcGISService _arcGISService;
+    private readonly IArcGISService _arcGISService;
 
-    public UserController(ArcGISService arcGISService)
+    public UserController(IArcGISService arcGISService)
     {
         _arcGISService = arcGISService;
     }
@@ -17,6 +17,6 @@ public class UserController : ControllerBase
     [HttpPost()]
     public async Task<IActionResult> GetAllUsers()
     {
-        return Ok(await _arcGISService.GetAllUsers());
+        return Ok(await _arcGISService.GetAllUsersAsync());
     }
 }

--- a/PortalGenius.Api/Program.cs
+++ b/PortalGenius.Api/Program.cs
@@ -39,7 +39,7 @@ builder.Services.AddHttpClient("arcgis-api", options =>
 });
 builder.Services.AddHttpService("arcgis-api");
 
-builder.Services.AddTransient<ArcGISService>();
+builder.Services.AddTransient<IArcGISService, ArcGISService>();
 
 var app = builder.Build();
 

--- a/PortalGenius.Core/Interfaces/IArcGISService.cs
+++ b/PortalGenius.Core/Interfaces/IArcGISService.cs
@@ -1,0 +1,9 @@
+﻿namespace PortalGenius.Core.Services
+{
+    public interface IArcGISService
+    {
+        public Task<object> GetAllItemsAsync();
+
+        public Task<object> GetAllUsersAsync();
+    }
+}

--- a/PortalGenius.Core/Interfaces/IHttpService.cs
+++ b/PortalGenius.Core/Interfaces/IHttpService.cs
@@ -1,0 +1,9 @@
+﻿namespace PortalGenius.Core.Services
+{
+    public interface IHttpService
+    {
+        public Task<T> GetAsync<T>(string path);
+
+        public Task<T> PostAsync<T>(string path, object requestBody);
+    }
+}

--- a/PortalGenius.Core/Services/ArcGISService.cs
+++ b/PortalGenius.Core/Services/ArcGISService.cs
@@ -2,14 +2,14 @@
 
 namespace PortalGenius.Core.Services
 {
-    public class ArcGISService
+    public class ArcGISService : IArcGISService
     {
-        private readonly HttpService _httpService;
+        private readonly IHttpService _httpService;
 
         private readonly ILogger<ArcGISService> _logger;
 
         public ArcGISService(
-            HttpService httpService,
+            IHttpService httpService,
             ILogger<ArcGISService> logger
         )
         {
@@ -17,13 +17,13 @@ namespace PortalGenius.Core.Services
             _logger = logger;
         }
 
-        public async Task<object> GetAllItems()
+        public async Task<object> GetAllItemsAsync()
         {
             // TODO: Make accountId dynamic
             return await _httpService.GetAsync<object>("search?q=accountid:v16XTZeIhHAZEpwh&f=json");
         }
 
-        public async Task<object> GetAllUsers()
+        public async Task<object> GetAllUsersAsync()
         {
             return await _httpService.GetAsync<object>("portals/x/users?f=json&token=6Jv9FkkWq7T78yD4Egh_2ZIDhv39DWlMBN_ps49ibz0EBihF8pJ7hgrO6Ru_yjGRXWoT9IKAKGEwikddYyBlTfLXo-zYk0eW1EVqdgR7MI2LGtLoRg8YNoNaHp01kCRoVfbAmh6Xm_6IJQcz2le647fvR9FXwtb7EQ-SRwAz2Zbf6xwPohkF6lBjhcoEoPdTHw-6X5iwKADpJEKOtb2fwQ..&searchUserAccess=*&filter=*&num=100");
         }

--- a/PortalGenius.Core/Services/HttpService/HttpService.cs
+++ b/PortalGenius.Core/Services/HttpService/HttpService.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace PortalGenius.Core.Services
 {
-    public class HttpService
+    public class HttpService : IHttpService
     {
         private readonly HttpClient _httpClient;
 

--- a/PortalGenius.Core/Services/HttpService/HttpServiceCollectionExtentions.cs
+++ b/PortalGenius.Core/Services/HttpService/HttpServiceCollectionExtentions.cs
@@ -5,7 +5,7 @@ namespace PortalGenius.Core.Services
     public class HttpServiceOptions
     {
         /// <summary>
-        /// The name of the <see cref="HttpClient"/> to use.
+        ///     The name of the <see cref="HttpClient"/> to use.
         /// </summary>
         public string HttpClientName { get; set; }
     }
@@ -13,8 +13,8 @@ namespace PortalGenius.Core.Services
     public static class HttpServiceCollectionExtentions
     {
         /// <summary>
-        /// Adds the custom <see cref="HttpService"/> class to the service the service collection.
-        /// This method accepts a <paramref name="clientName"/> to specify whichs <see cref="HttpClient"/> should be used in the <see cref="HttpService"/>.
+        ///     Adds the custom <see cref="HttpService"/> class to the service the service collection.
+        ///     This method accepts a <paramref name="clientName"/> to specify whichs <see cref="HttpClient"/> should be used in the <see cref="HttpService"/>.
         /// </summary>
         /// <param name="services">The service collection to add the <see cref="HttpService"/> to.</param>
         /// <param name="clientName">The name of the <see cref="HttpClient"/> to use.</param>

--- a/PortalGenius.Core/Services/HttpService/HttpServiceCollectionExtentions.cs
+++ b/PortalGenius.Core/Services/HttpService/HttpServiceCollectionExtentions.cs
@@ -33,7 +33,7 @@ namespace PortalGenius.Core.Services
             });
 
             // Add the HttpService to the service collection
-            return services.AddTransient<HttpService>();
+            return services.AddTransient<IHttpService, HttpService>();
         }
     }
 }

--- a/PortalGenius.WPF/App.xaml.cs
+++ b/PortalGenius.WPF/App.xaml.cs
@@ -30,7 +30,7 @@ namespace PortalGenius.WPF
             });
 
             services.AddHttpService("local-api");
-            services.AddTransient<ArcGISService>();
+            services.AddTransient<IArcGISService, ArcGISService>();
 
             // Windows
             services.AddSingleton<MainWindow>();

--- a/PortalGenius.WPF/ShowAPIoutput.xaml.cs
+++ b/PortalGenius.WPF/ShowAPIoutput.xaml.cs
@@ -1,5 +1,5 @@
-﻿using PortalGenius.Core.Services;
-using JSONTreeView;
+﻿using JSONTreeView;
+using PortalGenius.Core.Services;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -10,9 +10,9 @@ namespace PortalGenius.WPF
     /// </summary>
     public partial class ShowAPIoutput : Page
     {
-        private readonly ArcGISService _arcGISService;
+        private readonly IArcGISService _arcGISService;
 
-        public ShowAPIoutput(ArcGISService arcGISService)
+        public ShowAPIoutput(IArcGISService arcGISService)
         {
             _arcGISService = arcGISService;
 
@@ -23,7 +23,7 @@ namespace PortalGenius.WPF
             //UserController U1 = new UserController();
             //ItemController itemcontroller = new ItemController();
             //Output.Text = itemcontroller.Post();
-            Data.ProcessJson((await _arcGISService.GetAllItems()).ToString());
+            Data.ProcessJson((await _arcGISService.GetAllItemsAsync()).ToString());
         }
     }
 }


### PR DESCRIPTION
Ter voorbereiding op integratietesten, heb ik de serviceklassen nu een implementatie laten zijn van diens interface.
Dit geeft als mogelijkheid om meerdere implementaties te maken van de serviceklassen, waaronder voor mocking.

Als je in het vervolg een service wilt gebruiken, moet je de **interface** injecteren.

Tot slot heb ik de methodenamen van de ArcGIS-service klasse voorzien van de `Async` suffix om in lijn te blijven met de andere methodes en om bij gebruik de herinnering op te roepen dat de methode async is.